### PR TITLE
Add a workaround for Apple Silicon

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,12 @@
 # DurianSwt releases
 
 ## [Unreleased]
+### Added
+- On Mac Apple Silicon (but not x86_64), SWT Tables and Trees now have giant fat rows ([bugzilla](https://bugs.eclipse.org/bugs/show_bug.cgi?id=575696)). ([#17](https://github.com/diffplug/durian-swt/pull/17))
+  - But if you call `setFont(null)` on them, then they have rows the same size as before.
+  - We created a new class `SiliconFix` that does nothing on all platforms except Apple Silicon where it calls `setFont(null)`.
+  - Wherever a `Table` or `Tree` instantiated (`SmoothTable` and `ColumnFormat`), we use `SiliconFix`.
+  - This workaround is perfectly effective as of `4.21` and `4.22`, it may become obsolete in a future release.
 
 ## [3.5.0] - 2021-09-03
 ### Added

--- a/durian-swt/src/main/java/com/diffplug/common/swt/ColumnFormat.java
+++ b/durian-swt/src/main/java/com/diffplug/common/swt/ColumnFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2021 DiffPlug
+ * Copyright (C) 2020-2022 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -104,6 +104,7 @@ public class ColumnFormat {
 		SwtMisc.assertClean(parent);
 		// create the control
 		Table control = new Table(parent, style);
+		SiliconFix.fix(control);
 		control.setLinesVisible(linesVisible);
 		control.setHeaderVisible(headerVisible);
 
@@ -152,6 +153,7 @@ public class ColumnFormat {
 		SwtMisc.assertClean(parent);
 		// create the control
 		Tree control = new Tree(parent, style);
+		SiliconFix.fix(control);
 		control.setLinesVisible(linesVisible);
 		control.setHeaderVisible(headerVisible);
 

--- a/durian-swt/src/main/java/com/diffplug/common/swt/SiliconFix.java
+++ b/durian-swt/src/main/java/com/diffplug/common/swt/SiliconFix.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2022 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.common.swt;
+
+
+import com.diffplug.common.swt.os.Arch;
+import com.diffplug.common.swt.os.OS;
+import org.eclipse.swt.widgets.List;
+import org.eclipse.swt.widgets.Table;
+import org.eclipse.swt.widgets.Tree;
+
+/**
+ * Call these methods whenever a `Table`, `Tree`, or `List` is instantiated and it will do nothing,
+ * excpet on Mac Apple Silicon where it will call `setFont(null)` as a workaround for
+ * https://bugs.eclipse.org/bugs/show_bug.cgi?id=575696
+ */
+public class SiliconFix {
+	private static final boolean APPLY_FIX = OS.getRunning().isMac() && Arch.getRunning() == Arch.arm64;
+
+	public static void fix(Table table) {
+		if (APPLY_FIX) {
+			table.setFont(null);
+		}
+	}
+
+	public static void fix(Tree tree) {
+		if (APPLY_FIX) {
+			tree.setFont(null);
+		}
+	}
+
+	public static void fix(List list) {
+		if (APPLY_FIX) {
+			list.setFont(null);
+		}
+	}
+}

--- a/durian-swt/src/main/java/com/diffplug/common/swt/widgets/AbstractSmoothTable.java
+++ b/durian-swt/src/main/java/com/diffplug/common/swt/widgets/AbstractSmoothTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 DiffPlug
+ * Copyright (C) 2020-2022 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 package com.diffplug.common.swt.widgets;
 
 
+import com.diffplug.common.swt.SiliconFix;
 import java.util.function.DoubleConsumer;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Point;
@@ -58,6 +59,7 @@ abstract class AbstractSmoothTable extends Composite {
 		}
 		// the table can't have the BORDER
 		table = new Table(this, style & (~SWT.BORDER));
+		SiliconFix.fix(table);
 		this.setBackground(table.getBackground());
 		rowHeight = table.getItemHeight();
 		itemCount = table.getItemCount();


### PR DESCRIPTION
- On Mac Apple Silicon (but not x86_64), SWT Tables and Trees now have giant fat rows ([bugzilla](https://bugs.eclipse.org/bugs/show_bug.cgi?id=575696)).
  - But if you call `setFont(null)` on them, then they have rows the same size as before.
  - We created a new class `SiliconFix` that does nothing on all platforms except Apple Silicon where it calls `setFont(null)`.
  - Wherever a `Table` or `Tree` instantiated (`SmoothTable` and `ColumnFormat`), we use `SiliconFix`.
  - This workaround is perfectly effective as of Eclipse `4.21` and `4.22`, it may become obsolete in a future release.
