### PR TITLE
Add `Arch.unknown`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,8 @@
 # DurianSwt releases
 
 ## [Unreleased]
+### Added
+- When `OS.getNative` or `getRunning` is called on an OS which is unsupported by SWT, instead of throwing an exception, we now return `Arch.unknown`. You can't get platform-specific artifacts for it, but if you don't need them then you get to keep running instead of dying. ([#21](https://github.com/diffplug/durian-swt/pull/21))
 
 ## [4.1.1] - 2022-10-31
 ### Fixed

--- a/durian-swt.os/src/main/java/com/diffplug/common/swt/os/Arch.java
+++ b/durian-swt.os/src/main/java/com/diffplug/common/swt/os/Arch.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 DiffPlug
+ * Copyright (C) 2020-2023 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@ package com.diffplug.common.swt.os;
 
 /** Enum for handling different processor architectures supported by SWT. */
 public enum Arch {
-	x86, x64, arm64;
+	x86, x64, arm64, unknown;
 
 	/** Returns the appropriate value depending on the arch. */
 	public <T> T x86x64(T val86, T val64) {
@@ -52,6 +52,22 @@ public enum Arch {
 			return val64;
 		case arm64:
 			return arm64;
+		default:
+			throw unsupportedException(this);
+		}
+	}
+
+	/** Returns the appropriate value depending on the arch. */
+	public <T> T x86x64arm64unknown(T val86, T val64, T arm64, T unknown) {
+		switch (this) {
+		case x86:
+			return val86;
+		case x64:
+			return val64;
+		case arm64:
+			return arm64;
+		case unknown:
+			return unknown;
 		default:
 			throw unsupportedException(this);
 		}

--- a/durian-swt.os/src/main/java/com/diffplug/common/swt/os/SwtPlatform.java
+++ b/durian-swt.os/src/main/java/com/diffplug/common/swt/os/SwtPlatform.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 DiffPlug
+ * Copyright (C) 2020-2023 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 package com.diffplug.common.swt.os;
-
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -129,7 +128,7 @@ public class SwtPlatform {
 	public static SwtPlatform fromOS(OS raw) {
 		String ws = raw.winMacLinux("win32", "cocoa", "gtk");
 		String os = raw.winMacLinux("win32", "macosx", "linux");
-		String arch = raw.getArch().x86x64arm64("x86", "x86_64", "aarch64");
+		String arch = raw.getArch().x86x64arm64unknown("x86", "x86_64", "aarch64", "unknown");
 		return new SwtPlatform(ws, os, arch);
 	}
 


### PR DESCRIPTION
- to resolve #20

When `OS.getNative` or `getRunning` is called on an OS which is unsupported by SWT, instead of throwing an exception, we now return `Arch.unknown`. You can't get platform-specific artifacts for it, but if you don't need them then you get to keep running instead of dying.