### PR TITLE
Fix architecture detection on MacOS to be configuration-cache friendly

### DIFF
--- a/durian-swt.os/src/main/java/com/diffplug/common/swt/os/OS.java
+++ b/durian-swt.os/src/main/java/com/diffplug/common/swt/os/OS.java
@@ -133,7 +133,7 @@ public enum OS {
 		boolean isMac = os_name.contains("mac");
 		boolean isLinux = Arrays.asList("nix", "nux", "aix").stream().anyMatch(os_name::contains);
 		if (isMac) {
-			return exec("uname", "-a").contains("_ARM64_") ? MAC_silicon : MAC_x64;
+			return systemProperty.apply("os.arch").equals("aarch64") ? MAC_silicon : MAC_x64;
 		} else if (isWin) {
 			boolean is64bit = environmentVariable.apply("ProgramFiles(x86)") != null;
 			return is64bit ? WIN_x64 : WIN_x86;


### PR DESCRIPTION
See https://github.com/diffplug/goomph/issues/211.  Executing `uname -a` causes configuration cache issues, so get the info from the `os.arch` system property instead.